### PR TITLE
fix to allow special characters

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,7 +11,7 @@ local function get_formspec()
 	if news_file then
 		local news = news_file:read("*a")
 		news_file:close()
-		news_fs = news_fs.."textarea[0.25,0;12.1,9;news;;"..news.."]"
+		news_fs = news_fs.."textarea[0.25,0;12.1,9;news;;"..minetest.formspec_escape(news).."]"
 	else
 		news_fs = news_fs.."textarea[0.25,0;12.1,9;news;;No current news.]"
 	end


### PR DESCRIPTION
Previously, this code didn't render text if it contained code that could be formspec code such as [square brackets].
According to the Minetest Lua API, text that might contain formspec code must be escaped:

>When displaying text which can contain formspec code, e.g. text set by a player, use `minetest.formspec_escape`.
https://github.com/minetest/minetest/blob/master/doc/lua_api.txt

This simple fix will allow these characters to display correctly if written in news.txt.
I tested it on my server and it works.